### PR TITLE
Clarifying container vs image wording in README.md requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ A Test Kitchen Driver for Lxd.
 
 Lxd version of 2.3 (the one where "lxc network" commands were introduced) or higher is required for
 this driver which means that a native package must be installed on the system running Test Kitchen.
-You must also prepare a container to be used by Test Kitchen. For that make sure there is ssh daemon
+You must also prepare an image to be used by Test Kitchen. For that make sure there is ssh daemon
 installed and starting on boot. ( On Ubuntu it can be done by simply installing 'openssh-server'
 package. ) You can also install Chef Client there, if you do not want Test Kitchen to install it
-every time the container is started.
+every time a container is generated from the image.
 
 ## <a name="installation"></a> Installation and Setup
 


### PR DESCRIPTION
The README uses the work 'container' when it really means image, which may create some confusion.

I almost didn't try out this driver because I thought it was saying that containers had to be created beforehand, when it really just means that an image might have to be prepared for it.

As a side note, when I pulled the default Ubuntu 16.04 container from the default image server 'openssh-server' was already installed and I got everything working without having to create my own image.